### PR TITLE
dockerisation de la bdd covid

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+
+services:
+ 
+  db:
+    image: bdd:latest
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+ 
+volumes:
+  pgdata:
+ 

--- a/docker/postgre/dockerfile
+++ b/docker/postgre/dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:12.14
+
+COPY *.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Dockerisation de la bdd sql covid :+1: 

1. Placez-vous dans docker/postgre `docker image build . -t bdd:latest`
2. Placez-vous dans docker `docker compose up`

En attendant la containerisation de l'API : utiliser l'addresse ip de votre container pour faire les requêtes SQL